### PR TITLE
Say which Node version is expected.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "24"
+  },
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",
     "jsdom": "^27.0.0",


### PR DESCRIPTION
You're using `Object.groupBy`, which was added in Node 21.something (https://github.com/w3ctag/tpac-meetings/actions/runs/19203374973/job/54895051808), but since 24 is LTS now, may as well suggest that.